### PR TITLE
Use RecursiveDirectoryIterator instead of scandir().

### DIFF
--- a/packages/class-files-iterator/tests/src/NsDirUtilTest.php
+++ b/packages/class-files-iterator/tests/src/NsDirUtilTest.php
@@ -58,7 +58,7 @@ class NsDirUtilTest extends TestCase {
     // Only read permissions, no execute bit.
     // The directory will appear as empty.
     chmod($dir, $perms & 0444);
-    $this->assertNull(NsDirUtil::iterate($dir, '')->key());
+    $this->assertSame($file, NsDirUtil::iterate($dir, '')->key());
     $this->assertFalse(@include $file);
   }
 
@@ -85,9 +85,9 @@ class NsDirUtilTest extends TestCase {
     $f($dir);
   }
 
-  public function testScanKnownDir(): void {
-    $f = NsDirUtil::scanKnownDir(...);
-    $this->callAndAssertException(\RuntimeException::class, fn () => $f(__DIR__ . '/NonExistingDir'));
+  public function testGetDirContents(): void {
+    $f = NsDirUtil::getDirContents(...);
+    $this->callAndAssertException(\UnexpectedValueException::class, fn () => $f(__DIR__ . '/NonExistingDir'));
   }
 
 }


### PR DESCRIPTION
This is a major performance improvement.

Both `scandir()` and `\RecursiveDirectoryIterator` have a similar performance for the main scan operation.\
However, with `scandir()` and also with `\DirectoryIterator` or `\FilesystemIterator`, we lose additional time on `is_file()` / `is_dir()` or `->isFile()` / `->isDir()`, respectively.\
With `\RecursiveDirectoryIterator` we can use `->hasChildren()` instead, which is much faster, because the information has already been collected during the scan process.